### PR TITLE
✦ Fix UNI_SLOT on ethereum network for Constant.sol test

### DIFF
--- a/src/test/ethereum/Constants.sol
+++ b/src/test/ethereum/Constants.sol
@@ -23,7 +23,7 @@ uint256 constant USDT_SLOT = 2;
 address constant WETH_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 uint256 constant WETH_SLOT = 3;
 address constant UNI_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984;
-uint256 constant UNI_SLOT = 51;
+uint256 constant UNI_SLOT = 4;
 address constant GOHM_ADDRESS = 0x0ab87046fBb341D058F17CBC4c1133F25a20a52f;
 uint256 constant GOHM_SLOT = 0;
 


### PR DESCRIPTION
File: `src/test/ethereum/Constants.sol`

Before: `uint256 constant UNI_SLOT = 51;`
After: `uint256 constant UNI_SLOT = 4;`